### PR TITLE
Fix module import support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "tsx watch src .env | pino-pretty --colorize",
     "pretest": "npm run build",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest -w"
   },
   "repository": {
@@ -45,6 +46,7 @@
     "@types/node": "^18.11.15",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
+    "@vitest/coverage-c8": "^0.31.0",
     "esbuild": "^0.14.54",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
@@ -53,6 +55,6 @@
     "prettier": "^2.8.0",
     "tsx": "^3.12.1",
     "typescript": "^4.9.3",
-    "vitest": "^0.25.8"
+    "vitest": "^0.31.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check:types": "tsc --noEmit",
-    "build": "esbuild `find src \\( -name '*.ts' \\)` --platform=node --outdir=build --resolve-extensions=.js",
+    "build": "node --experimental-json-modules scripts/build.js",
     "build:docker:prod": "docker build . -t my-fastify-app --build-arg APP_ENV=production",
     "start": "node build",
     "dev": "tsx watch src .env | pino-pretty --colorize",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,21 @@
+import { build } from "esbuild";
+import PackageJson from '../package.json' assert { type: "json" };
+
+let { dependencies, peerDependencies } = PackageJson;
+
+dependencies = !dependencies ? {} : dependencies;
+peerDependencies = !peerDependencies ? {}: peerDependencies;
+
+const sharedConfig = {
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  // minify: true,
+  external: Object.keys(dependencies).concat(Object.keys(peerDependencies)),
+};
+
+await build({
+  ...sharedConfig,
+  outdir: "build",
+  platform: 'neutral', // for ESM
+  format: "esm",
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      // reportsDirectory: './tests/coverage',
+      provider: 'c8',
+      // reporter: ['text', 'json', 'html'],
+    },
+  },
+})


### PR DESCRIPTION
Change build method to one bundle with external node_modules import.

The file structure of the build is lost, but modules can be imported within the project (without **.js** extension), ex: `import server from './server';`.

