### PR TITLE
add vite dependency and update to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prettier": "^2.8.0",
     "tsx": "^3.12.1",
     "typescript": "^4.9.3",
-    "vitest": "^0.25.8"
+    "vite": "latest",
+    "vitest": "latest"
   }
 }


### PR DESCRIPTION
This PR resolves #10 where after running `pnpm install` and `pnpm build`, running `pnpm test` would fail. This seems to be due to a missing dependency for `vite`.